### PR TITLE
ENH: Fixes for singularity

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,7 +44,7 @@ RUN curl -sSL https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64
     rm /tmp/miniconda.sh
 ENV PATH=$CONDA_DIR/bin:$PATH
 RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.profile
-RUN conda init bash
+RUN conda init --system bash
 
 COPY --from=mrtrix301 /opt/mrtrix3 /opt/mrtrix3
 

--- a/dstripe/eval_stripes3.py
+++ b/dstripe/eval_stripes3.py
@@ -455,8 +455,8 @@ if __name__ == '__main__':
         checkpoint = args.checkpoint
     assert os.path.isfile(checkpoint), checkpoint
     eprint('checkpoint:'.rjust(15, ' '), checkpoint)
-    params = params_in + '_val'
-
+    params_basename = os.path.basename(params_in) + "_val"
+    params = os.path.join(outdir, params_basename)
     eprint("=" * 100)
 
     if not os.path.isdir(valpath):


### PR DESCRIPTION
Hi @maxpietsch 

Thanks for releasing this tool. I was trying to get it running on Singularity, and have had success with these changes.

In the Dockerfile, I changed `conda init bash` to `conda init --system bash`, so that conda is initialized system wide. This was needed to prevent the error

```
CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
To initialize your shell, run

    $ conda init <SHELL_NAME>

Currently supported shells are:
  - bash
  - fish
  - tcsh
  - xonsh
  - zsh
  - powershell

See 'conda init --help' for more information and options.

IMPORTANT: You may need to close and restart your shell after running 'conda init'.
```

After fixing conda, I had to change eval_stripes3 to not write to read-only locations in a singularity image. It was a small fix, just preventing it trying to write the parameter file to /opt. I set it to write to the output directory instead.

At run time, users may want to pass '-scratch /tmp' to point the scratch directory to /tmp or some other writeable location. The default is the user home directory, which is automatically mounted by singularity unless `--no-home` is specified, but each job writes a few hundred Mb to $HOME, which might not be OK for cluster users, so `-scratch` is a good option for singularity users to know about.

I've only run the CPU version so far.